### PR TITLE
Fix question submit failing with mouse selections in focus mode

### DIFF
--- a/src/adapters/notification-coordinator.ts
+++ b/src/adapters/notification-coordinator.ts
@@ -134,6 +134,8 @@ export class NotificationCoordinator {
             questionSend: (id: string) => o?.questionSend(id),
             questionDismiss: (id: string) => o?.questionDismiss(id),
             questionVisit: (id: string) => o?.questionVisit(id),
+            syncSelectOption: (id: string, qi: number, oi: number) => this._syncQuestionToDomain(id, ns => domainSelectQuestionOption(ns, id, qi, oi)),
+            syncSetOtherText: (id: string, qi: number, text: string) => this._syncQuestionToDomain(id, ns => domainSetOtherText(ns, id, qi, text)),
             extensionPath: d.extensionPath,
         };
     }

--- a/src/adapters/notification-focus-mode.ts
+++ b/src/adapters/notification-focus-mode.ts
@@ -52,6 +52,10 @@ interface FocusModeDeps {
     questionSend(id: string): void;
     questionDismiss(id: string): void;
     questionVisit(id: string): void;
+    /** Sync a question interaction to domain (for mouse selections on focus mode card). */
+    syncSelectOption(id: string, questionIndex: number, optionIndex: number): void;
+    /** Sync "Other" text to domain (for mouse edits on focus mode card). */
+    syncSetOtherText(id: string, questionIndex: number, text: string): void;
     extensionPath: string;
 }
 
@@ -526,6 +530,8 @@ export class NotificationFocusMode {
             extensionPath: this._deps.extensionPath,
             onRespond: (nid, action) => this._deps.respondToEntry(nid, action),
             onVisitSession: (sid) => this._deps.visitSession(sid),
+            onSelectOption: (id, qi, oi) => this._deps.syncSelectOption(id, qi, oi),
+            onSetOtherText: (id, qi, text) => this._deps.syncSetOtherText(id, qi, text),
         }, true, overlayCard.getSharedState());
         this._focusModeQuestionCard = focusCard;
         return focusCard.actor as St.BoxLayout;


### PR DESCRIPTION
## Summary
- Focus mode's QuestionCard was missing `onSelectOption` and `onSetOtherText` callbacks, so mouse clicks on options updated the card's local UI state but never synced answers to the domain
- When submitting via keyboard (key 1), `_trySubmitQuestion` checked `canSubmitQuestion` against the domain's empty `questionState.answers` and silently refused
- Abort (key 2) was unaffected because `questionDismiss` doesn't check `canSubmitQuestion`

## Test plan
- [ ] Open a question notification with multiple questions
- [ ] In focus mode, select options using **mouse clicks** on the focus mode card
- [ ] Press key 1 on the summary page to submit — should now work
- [ ] Verify the hook script completes and Claude Code receives the answers

🤖 Generated with [Claude Code](https://claude.com/claude-code)